### PR TITLE
Don't install go.mod and go.sum

### DIFF
--- a/debian/not-installed
+++ b/debian/not-installed
@@ -1,0 +1,2 @@
+usr/share/gocode/src/github.com/farsightsec/sielink/go.mod
+usr/share/gocode/src/github.com/farsightsec/sielink/go.sum


### PR DESCRIPTION
I was getting build failures for dh_install warnings because go.mod and go.sum were in the debian tmp directory, but not picked up by any package. I've seen some packages that ship them and some that don't. If we need to ship them somewhere, I can update that, but for now, this will allow the package to build again.